### PR TITLE
Added an initial version of tcp socket leak check

### DIFF
--- a/lib/pedant/checks/socket_leak.rb
+++ b/lib/pedant/checks/socket_leak.rb
@@ -24,13 +24,6 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ################################################################################
 
-##
-# This module can identify simple socket leaks (socket was opened
-# but never closed). Unfortunately, this implementation only works
-# in immediate block scope (ie doesn't search up a block or down
-# a block for the close). As such, false positives/negatives can
-# occur. Which is why this uses the "warning" report
-##
 module Pedant
   class CheckSocketLeak < Check
     def self.requires

--- a/lib/pedant/checks/socket_leak.rb
+++ b/lib/pedant/checks/socket_leak.rb
@@ -115,7 +115,7 @@ module Pedant
                                           bnode.name.ident.name == "audit")))
             report_findings(found)
           elsif bnode.is_a?(Nasl::If)
-            if (bnode.cond.is_a?(Nasl::Expression))
+            if (bnode.cond.is_a?(Nasl::Expression) and bnode.cond.rhs.is_a?(Nasl::Lvalue))
               if bnode.cond.op.to_s() == "!"
                 if found.any? {|varName| varName == bnode.cond.rhs.ident.name}
                   # don't go down this path. This is the !soc path

--- a/lib/pedant/checks/socket_leak.rb
+++ b/lib/pedant/checks/socket_leak.rb
@@ -78,11 +78,17 @@ module Pedant
                 end
               end
             end
+          elsif bnode.is_a?(Nasl::Return)
+            # if the socket we are tracking gets returned then never mark it as
+            # a leak
+            if bnode.expr.is_a?(Nasl::Lvalue)
+                found = found - [bnode.expr.ident.name]
+            end
           end
         end
         return found
       end
-      
+
       allFound = Set.new
       tree.all(:Block).each do |node|
         allFound.merge(find_open_call(node.body))

--- a/lib/pedant/checks/socket_leak.rb
+++ b/lib/pedant/checks/socket_leak.rb
@@ -1,0 +1,114 @@
+################################################################################
+# Copyright (c) 2016, Tenable Network Security
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+################################################################################
+
+##
+# This module can identify simple socket leaks (socket was opened
+# but never closed). Unfortunately, this implementation only works
+# in immediate block scope (ie doesn't search up a block or down
+# a block for the close). As such, false positives/negatives can
+# occur. Which is why this uses the "warning" report
+##
+module Pedant
+  class CheckSocketLeak < Check
+    def self.requires
+      super + [:trees]
+    end
+
+    def check(file, tree)
+      def find_open_call(node)
+        found = Set.new
+        node.each do |bnode|
+          if bnode.is_a?(Nasl::Call)
+            if (bnode.name.ident.name == "open_sock_tcp")
+              found.add("")
+            elsif (bnode.name.ident.name == "close")
+              found = found - [bnode.args[0].expr.ident.name]
+            end
+          elsif bnode.is_a?(Nasl::Assignment)
+            name = ""
+            if bnode.lval.is_a?(Nasl::Lvalue)
+              name = bnode.lval.ident.name;
+            end
+            if bnode.expr.is_a?(Nasl::Call)
+              if (bnode.expr.name.ident.name == "open_sock_tcp")
+                found.add(name)
+              end
+            end
+          elsif bnode.is_a?(Nasl::Local)
+            bnode.idents.each do |idents|
+              if idents.is_a?(Nasl::Assignment)
+                name = ""
+                if idents.lval.is_a?(Nasl::Lvalue)
+                  name = idents.lval.ident.name
+                elsif idents.lval.is_a?(Nasl::Identifier)
+                  name = idents.lval.name
+                end
+                if idents.expr.is_a?(Nasl::Call)
+                  if (idents.expr.name.ident.name == "open_sock_tcp")
+                    found.add(name)
+                  end
+                end
+              end
+            end
+          end
+        end
+        return found
+      end
+      
+      allFound = Set.new
+      tree.all(:Block).each do |node|
+        allFound.merge(find_open_call(node.body))
+      end
+      
+      # The main body of a file is not a Block, so it must be considered
+      # separately.
+      allFound.merge(find_open_call(tree))
+
+      if allFound.size() > 0
+        warn
+        output = ""
+        allFound.each do |handle|
+          if !output.empty?
+            output += ", "
+          end
+          if handle == ""
+            handle = "<unassigned>"
+          end
+          output += handle
+        end
+        report(:warn, "Possibly leaked socket handle(s): " + output)
+      end
+    end
+
+    def run
+      # This check will pass by default.
+      pass
+
+      # Run this check on the tree from every file.
+      @kb[:trees].each { |file, tree| check(file, tree) }
+    end
+  end
+end

--- a/lib/pedant/checks/socket_leak.rb
+++ b/lib/pedant/checks/socket_leak.rb
@@ -45,7 +45,8 @@ module Pedant
     def check(file, tree)
       ##
       # Examines a single passed in node and tries to appropriately handle it
-      # based on the type.
+      # based on the type. This function ignores "g_sock" and _ssh_socket as both
+      # of these are handled in a way that this parser can't really handle
       #
       # @param bnode the node to examine
       # @param found a set of active "open_sock_tcp" items
@@ -66,6 +67,9 @@ module Pedant
               if bnode.args[0].expr.is_a?(Nasl::Lvalue)
                 found = found - [bnode.args[0].expr.ident.name]
               end
+            elsif (bnode.name.ident.name == "session_init" ||
+                   bnode.name.ident.name == "ssh_close_connection")
+              pass
             end
           elsif bnode.is_a?(Nasl::Assignment)
             name = ""
@@ -73,8 +77,9 @@ module Pedant
               name = bnode.lval.ident.name;
             end
             if bnode.expr.is_a?(Nasl::Call)
-              if (bnode.expr.name.ident.name == "open_sock_tcp" ||
-                  bnode.expr.name.ident.name == "http_open_socket")
+              if ((bnode.expr.name.ident.name == "open_sock_tcp" ||
+                  bnode.expr.name.ident.name == "http_open_socket") &&
+                  name != "g_sock" && name != "_ssh_socket")
                 found.add(name)
               end
             end
@@ -88,8 +93,9 @@ module Pedant
                   name = idents.lval.name
                 end
                 if idents.expr.is_a?(Nasl::Call)
-                  if (idents.expr.name.ident.name == "open_sock_tcp" ||
-                      idents.expr.name.ident.name == "http_open_socket")
+                  if ((idents.expr.name.ident.name == "open_sock_tcp" ||
+                      idents.expr.name.ident.name == "http_open_socket")  &&
+                      name != "g_sock" && name != "_ssh_socket")
                     found.add(name)
                   end
                 end

--- a/lib/pedant/checks/socket_leak.rb
+++ b/lib/pedant/checks/socket_leak.rb
@@ -37,8 +37,21 @@ module Pedant
       super + [:trees]
     end
 
+    ##
+    # Breaks the tree up into blocks and feeds them into block_parser
+    # @param file the current file being examined
+    # @param tree the entire file tree
+    ##
     def check(file, tree)
-              def node_parser(bnode, found)
+      ##
+      # Examines a single passed in node and tries to appropriately handle it
+      # based on the type.
+      #
+      # @param bnode the node to examine
+      # @param found a set of active "open_sock_tcp" items
+      # @return the new list of open_sock_tcp items
+      ##
+      def node_parser(bnode, found)
           if bnode.is_a?(Nasl::Call)
             if (bnode.name.ident.name == "open_sock_tcp")
               found.add("")
@@ -99,9 +112,15 @@ module Pedant
           return found
         end
 
-      def block_parser(node, found)
-        node.each do |bnode|
-          found = node_parser(bnode, found);
+      ##
+      # Iterates over the blocks and hands individual nodes up to the node_parser
+      # @param block the current Block node to examine
+      # @param found the current list of found open_sock_tcp
+      # @param all the found open_sock_tcp that haven't been closed
+      ##
+      def block_parser(block, found)
+        block.each do |node|
+          found = node_parser(node, found);
         end
         return found;
       end

--- a/lib/pedant/checks/socket_leak.rb
+++ b/lib/pedant/checks/socket_leak.rb
@@ -45,7 +45,12 @@ module Pedant
             if (bnode.name.ident.name == "open_sock_tcp")
               found.add("")
             elsif (bnode.name.ident.name == "close")
-              found = found - [bnode.args[0].expr.ident.name]
+              # Check that this is an Lvalue. It could be a call or something
+              # which is just too complicated to handle and doesn't really work
+              # with our variable tracking system
+              if bnode.args[0].expr.is_a?(Nasl::Lvalue)
+                found = found - [bnode.args[0].expr.ident.name]
+              end
             end
           elsif bnode.is_a?(Nasl::Assignment)
             name = ""

--- a/test/unit/checks/test_socket_leak.rb
+++ b/test/unit/checks/test_socket_leak.rb
@@ -1,0 +1,95 @@
+################################################################################
+# Copyright (c) 2016, Tenable Network Security
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+################################################################################
+
+class TestSockLeak < Test::Unit::TestCase
+  include Pedant::Test
+
+  def test_none
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q||
+    )
+  end
+  
+  def test_simple_no_close
+    check(
+      :warn,
+      :CheckSocketLeak,
+      %q|soc = open_sock_tcp(8080); exit(0);|
+    )
+  end
+  
+  def test_good_close
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|soc = open_sock_tcp(8080); close(soc);|
+    )
+  end
+  
+   def test_wrong_handle_close
+    check(
+      :warn,
+      :CheckSocketLeak,
+      %q|soc = open_sock_tcp(8080); close(sock);|
+    )
+  end
+
+   def test_local_var_no_close
+    check(
+      :warn,
+      :CheckSocketLeak,
+      %q|local_var soc = open_sock_tcp(8080); exit(0);|
+    )
+  end
+  
+  def test_local_var_close
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|local_var soc = open_sock_tcp(8080); close(soc);|
+    )
+  end
+
+  def test_local_var_close_wrong_handle
+    check(
+      :warn,
+      :CheckSocketLeak,
+      %q|local_var soc = open_sock_tcp(8080); close(sock);|
+    )
+  end
+  
+  # This is an example of what this parser can't handle.
+  #def test_local_var_close_wrong_handle
+  #  check(
+  #    :pass,
+  #    :CheckSocketLeak,
+  #    %q|local_var soc = open_sock_tcp(8080); if (soc) close(soc); exit(0);|
+  #  )
+  #end
+
+end

--- a/test/unit/checks/test_socket_leak.rb
+++ b/test/unit/checks/test_socket_leak.rb
@@ -108,4 +108,36 @@ class TestSockLeak < Test::Unit::TestCase
     )
   end
 
+  def test_ftp_close
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|{ soc = open_sock_tcp(8080); ftp_close(soc); exit(0); };|
+    )
+  end
+  
+  def test_smtp_close
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|{ soc = open_sock_tcp(8080); smtp_close(soc); exit(0); };|
+    )
+  end
+  
+  def test_http_open_close
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|{ soc = http_open_socket(8080); http_close_socket(soc); exit(0); };|
+    )
+  end
+  
+  def test_http_leak
+    check(
+      :warn,
+      :CheckSocketLeak,
+      %q|{ soc = http_open_socket(8080); exit(0); };|
+    )
+  end
+
 end

--- a/test/unit/checks/test_socket_leak.rb
+++ b/test/unit/checks/test_socket_leak.rb
@@ -140,4 +140,19 @@ class TestSockLeak < Test::Unit::TestCase
     )
   end
 
+  def ignore_smb
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|{ soc = http_open_socket(8080); session_init(0); };|
+    )
+  end
+  
+  def ignore_ssh
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|{ soc = open_sock_tcp(8080); ssh_close_connection(); };|
+    )
+  end
 end

--- a/test/unit/checks/test_socket_leak.rb
+++ b/test/unit/checks/test_socket_leak.rb
@@ -92,13 +92,20 @@ class TestSockLeak < Test::Unit::TestCase
     )
   end
 
-  # This is an example of what this parser can't handle.
-  #def test_local_var_close_wrong_handle
-  #  check(
-  #    :pass,
-  #    :CheckSocketLeak,
-  #    %q|local_var soc = open_sock_tcp(8080); if (soc) close(soc); exit(0);|
-  #  )
-  #end
+  def test_local_if_close
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|local_var soc = open_sock_tcp(8080); if (soc) close(soc); exit(0);|
+    )
+  end
+
+  def test_block_if_close
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|local_var soc = open_sock_tcp(8080); if (soc) { local_var test = 0; close(soc); } exit(0);|
+    )
+  end
 
 end

--- a/test/unit/checks/test_socket_leak.rb
+++ b/test/unit/checks/test_socket_leak.rb
@@ -155,4 +155,20 @@ class TestSockLeak < Test::Unit::TestCase
       %q|{ soc = open_sock_tcp(8080); ssh_close_connection(); };|
     )
   end
+
+  def test_ignore_soc_check
+    check(
+      :warn,
+      :CheckSocketLeak,
+      %q|{ soc = http_open_socket(8080); if (!soc) close(soc); exit(0); };|
+    )
+  end
+
+  def test_check_early_exit
+    check(
+      :warn,
+      :CheckSocketLeak,
+      %q|{ soc = open_sock_tcp(8080); if(test()) exit(1); close(soc); };|
+    )
+  end
 end

--- a/test/unit/checks/test_socket_leak.rb
+++ b/test/unit/checks/test_socket_leak.rb
@@ -83,6 +83,15 @@ class TestSockLeak < Test::Unit::TestCase
     )
   end
   
+  # To avoid false positives the check won't mark returned sockets as leaks
+  def test_created_socket_returned
+    check(
+      :pass,
+      :CheckSocketLeak,
+      %q|soc = open_sock_tcp(8080); return soc;|
+    )
+  end
+
   # This is an example of what this parser can't handle.
   #def test_local_var_close_wrong_handle
   #  check(


### PR DESCRIPTION
A better person would squash all these commits.

This detects socket leaks via open_sock_tcp and open_http_socket. We try to avoid false positives as much as possible (although I'm sure some still exist). I think the tests actually speak for the capabilities pretty well. The major think we can handle is if a socket is closed in a function that we can't see into (ie ssh_connection_close). 